### PR TITLE
fix: fixed to compile on Electron 13 (re-opened the pull request on a feature branch)

### DIFF
--- a/src/AppWrapper.h
+++ b/src/AppWrapper.h
@@ -163,7 +163,9 @@ void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
         behavior.message = [messagePf = std::move(messagePf), isolate](auto *ws, std::string_view message, uWS::OpCode opCode) {
             HandleScope hs(isolate);
 
-            Local<ArrayBuffer> messageArrayBuffer = ArrayBuffer::New(isolate, (void *) message.data(), message.length());
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) message.data(), message.length(), [](void*, size_t, void*){}, nullptr);
+            Local<ArrayBuffer> messageArrayBuffer = v8::ArrayBuffer::New(isolate, std::move(backing));
 
             PerSocketData *perSocketData = (PerSocketData *) ws->getUserData();
             Local<Value> argv[3] = {Local<Object>::New(isolate, perSocketData->socketPf),
@@ -215,7 +217,9 @@ void uWS_App_ws(const FunctionCallbackInfo<Value> &args) {
     behavior.close = [closePf = std::move(closePf), isolate](auto *ws, int code, std::string_view message) {
         HandleScope hs(isolate);
 
-        Local<ArrayBuffer> messageArrayBuffer = ArrayBuffer::New(isolate, (void *) message.data(), message.length());
+        std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) message.data(), message.length(), [](void*, size_t, void*){}, nullptr);
+        Local<ArrayBuffer> messageArrayBuffer = v8::ArrayBuffer::New(isolate, std::move(backing));
         PerSocketData *perSocketData = (PerSocketData *) ws->getUserData();
         Local<Object> wsObject = Local<Object>::New(isolate, perSocketData->socketPf);
 

--- a/src/HttpResponseWrapper.h
+++ b/src/HttpResponseWrapper.h
@@ -61,7 +61,9 @@ struct HttpResponseWrapper {
             res->onData([p = std::move(p), isolate](std::string_view data, bool last) {
                 HandleScope hs(isolate);
 
-                Local<ArrayBuffer> dataArrayBuffer = ArrayBuffer::New(isolate, (void *) data.data(), data.length());
+                std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) data.data(), data.length(), [](void*, size_t, void*){}, nullptr);
+                Local<ArrayBuffer> dataArrayBuffer = v8::ArrayBuffer::New(isolate, std::move(backing));
 
                 Local<Value> argv[] = {dataArrayBuffer, Boolean::New(isolate, last)};
                 CallJS(isolate, Local<Function>::New(isolate, p), 2, argv);
@@ -107,7 +109,9 @@ struct HttpResponseWrapper {
             std::string_view ip = res->getRemoteAddress();
 
             /* Todo: we need to pass a copy here */
-            args.GetReturnValue().Set(ArrayBuffer::New(isolate, (void *) ip.data(), ip.length()/*, ArrayBufferCreationMode::kInternalized*/));
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) ip.data(), ip.length(), [](void*, size_t, void*){}, nullptr);
+            args.GetReturnValue().Set(v8::ArrayBuffer::New(isolate, std::move(backing)/*, ArrayBufferCreationMode::kInternalized*/));
         }
     }
 
@@ -120,7 +124,10 @@ struct HttpResponseWrapper {
             std::string_view ip = res->getRemoteAddressAsText();
 
             /* Todo: we need to pass a copy here */
-            args.GetReturnValue().Set(ArrayBuffer::New(isolate, (void *) ip.data(), ip.length()/*, ArrayBufferCreationMode::kInternalized*/));
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) ip.data(), ip.length(), [](void*, size_t, void*){}, nullptr);
+
+            args.GetReturnValue().Set(v8::ArrayBuffer::New(isolate, std::move(backing)/*, ArrayBufferCreationMode::kInternalized*/));
         }
     }
 
@@ -133,7 +140,10 @@ struct HttpResponseWrapper {
             std::string_view ip = res->getProxiedRemoteAddress();
 
             /* Todo: we need to pass a copy here */
-            args.GetReturnValue().Set(ArrayBuffer::New(isolate, (void *) ip.data(), ip.length()/*, ArrayBufferCreationMode::kInternalized*/));
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) ip.data(), ip.length(), [](void*, size_t, void*){}, nullptr);
+
+            args.GetReturnValue().Set(v8::ArrayBuffer::New(isolate, std::move(backing)/*, ArrayBufferCreationMode::kInternalized*/));
         }
     }
 
@@ -146,7 +156,9 @@ struct HttpResponseWrapper {
             std::string_view ip = res->getProxiedRemoteAddressAsText();
 
             /* Todo: we need to pass a copy here */
-            args.GetReturnValue().Set(ArrayBuffer::New(isolate, (void *) ip.data(), ip.length()/*, ArrayBufferCreationMode::kInternalized*/));
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) ip.data(), ip.length(), [](void*, size_t, void*){}, nullptr);
+            args.GetReturnValue().Set(v8::ArrayBuffer::New(isolate, std::move(backing)/*, ArrayBufferCreationMode::kInternalized*/));
         }
     }
 

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -108,14 +108,14 @@ public:
             length = utf8Value->length();
         } else if (value->IsTypedArray()) {
             Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(value);
-            ArrayBuffer::Contents contents = arrayBufferView->Buffer()->GetContents();
+            std::shared_ptr<v8::BackingStore> backing = arrayBufferView->Buffer()-> GetBackingStore();
             length = arrayBufferView->ByteLength();
-            data = (char *) contents.Data() + arrayBufferView->ByteOffset();
+            data = (char *) backing->Data() + arrayBufferView->ByteOffset();
         } else if (value->IsArrayBuffer()) {
             Local<ArrayBuffer> arrayBuffer = Local<ArrayBuffer>::Cast(value);
-            ArrayBuffer::Contents contents = arrayBuffer->GetContents();
-            length = contents.ByteLength();
-            data = (char *) contents.Data();
+            std::shared_ptr<v8::BackingStore> backing = arrayBuffer-> GetBackingStore();
+            length = backing->ByteLength();
+            data = (char *) backing->Data();
         } else {
             invalid = true;
         }

--- a/src/WebSocketWrapper.h
+++ b/src/WebSocketWrapper.h
@@ -136,7 +136,9 @@ struct WebSocketWrapper {
             std::string_view ip = ws->getRemoteAddress();
 
             /* Todo: we need to pass a copy here */
-            args.GetReturnValue().Set(ArrayBuffer::New(isolate, (void *) ip.data(), ip.length()/*, ArrayBufferCreationMode::kInternalized*/));
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) ip.data(), ip.length(), [](void*, size_t, void*){}, nullptr);
+            args.GetReturnValue().Set(v8::ArrayBuffer::New(isolate, std::move(backing)/*, ArrayBufferCreationMode::kInternalized*/));
         }
     }
 
@@ -149,7 +151,9 @@ struct WebSocketWrapper {
             std::string_view ip = ws->getRemoteAddressAsText();
 
             /* Todo: we need to pass a copy here */
-            args.GetReturnValue().Set(ArrayBuffer::New(isolate, (void *) ip.data(), ip.length()/*, ArrayBufferCreationMode::kInternalized*/));
+            std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) ip.data(), ip.length(), [](void*, size_t, void*){}, nullptr);
+            args.GetReturnValue().Set(v8::ArrayBuffer::New(isolate, std::move(backing)/*, ArrayBufferCreationMode::kInternalized*/));
         }
     }
 

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -98,7 +98,9 @@ void uWS_getParts(const FunctionCallbackInfo<Value> &args) {
 
             std::string_view part = optionalPart.value();
 
-            Local<ArrayBuffer> partArrayBuffer = ArrayBuffer::New(isolate, (void *) part.data(), part.length());
+             std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                                                (void *) part.data(), part.length(), [](void*, size_t, void*){}, nullptr);
+            Local<ArrayBuffer> partArrayBuffer = v8::ArrayBuffer::New(isolate, std::move(backing));
             /* Map is 30% faster in this case, but a static Object could be faster still */
             Local<Object> partMap = Object::New(isolate);
             partMap->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "data", NewStringType::kNormal).ToLocalChecked(), partArrayBuffer).IsNothing();


### PR DESCRIPTION
This pull request makes it possible to build the binaries for Electron 13. You can try it out by running `./node_modules/.bin/electron-rebuild -v 13`

Deprecated ArrayBuffer methods have been removed from the v8.h used by Electron 13, and this prevented the previous version of this lib from compiling for Electron 13. The changes in this pull request have been made according to my current understanding of this document https://docs.google.com/document/d/1sTc_jRL87Fu175Holm5SV0kajkseGl2r8ifGY76G35k/edit#heading=h.5irk4csrpu0y and have not been tested for memory leaks nor performance.